### PR TITLE
added dependency for osgi to work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <netbeans.version>RELEASE113</netbeans.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <guava.version>[24.1.1,)</guava.version>
+        <version.slf4j>1.7.25</version.slf4j>
         <junit.version>4.13.1</junit.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -64,6 +65,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.slf4j}</version>
             </dependency>
             <dependency>
                 <groupId>org.netbeans.api</groupId>

--- a/vl-jung-nbm/pom.xml
+++ b/vl-jung-nbm/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>vl-jung</artifactId>
         </dependency>


### PR DESCRIPTION
I noticed that master branch would not build because of this:

[ERROR] Project uses classes from transitive OSGi bundle org.slf4j:slf4j-api:jar:1.7.25 which will not be accessible at runtime.
[INFO]     To fix the problem, add this module as direct dependency. For OSGi bundles that are supposed to be wrapped in NetBeans modules, use the useOSGiDependencies=false parameter

I made a small change to fix it.
